### PR TITLE
[READY] - init flake, simple slides and missing 19x content

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+BSD 3-Clause License
+
+Copyright (c) 2022-2023, Robert James Hernandez
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1669521532,
+        "narHash": "sha256-PIvE3KshYSOssKeFFZ97dgdQrXes/gvgvMTWGa9HN0g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "05198111c2b7ba69f105f0526b2e826bfaf9e1e6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "master",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  # Good overview of flakes: https://www.tweag.io/blog/2020-05-25-flakes/
+  inputs.nixpkgs.url = "nixpkgs/master";
+
+  outputs = flakes @ { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          self.overlays.default
+        ];
+        config = { allowUnfree = true; };
+      };
+    in
+    {
+      overlays.default =
+        (final: prev: rec {
+          texLive = final.texlive.combine {
+            inherit (final.texlive)
+              scheme-small
+              beamer
+              # Theme reqs
+              beamertheme-metropolis
+              pgfopts
+              multirow
+              ;
+          };
+          openwrt-at-scale = final.callPackage ./openwrt-at-scale/default.nix { };
+        });
+
+      devShells.x86_64-linux =
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs;[
+              rubber
+            ] ++ [ texLive ];
+          };
+        };
+    };
+  # Bold green prompt for `nix develop`
+  # Had to add extra escape chars to each special char
+  nixConfig.bash-prompt = "\\[\\033[01;32m\\][nix-flakes \\W] \$\\[\\033[00m\\] ";
+}

--- a/flake.nix
+++ b/flake.nix
@@ -26,8 +26,14 @@
               multirow
               ;
           };
+          simple-slides = final.callPackage ./simple/default.nix { };
           openwrt-at-scale = final.callPackage ./openwrt-at-scale/default.nix { };
         });
+
+        packages.x86_64-linux = {
+                import nixpkgs { system = "x86_64-linux"; overlays = [ self.overlay ]; };
+        inherit simple-slides;
+      };
 
       devShells.x86_64-linux =
         {

--- a/openwrt-at-scale/default.nix
+++ b/openwrt-at-scale/default.nix
@@ -1,30 +1,18 @@
-let
-  pkgs = import <nixpkgs> {};
+{ texLive, rubber, stdenv, lib }:
 
-  # https://ctan.org/ for what to combine in texlive
-  texlive = pkgs.texlive.combine {
-    inherit (pkgs.texlive)
-    scheme-small
-    beamer
-    # Theme reqs
-    beamertheme-metropolis
-    pgfopts
-    multirow
-    ;
-  };
-in {
-  slides = pkgs.stdenv.mkDerivation {
-    name = "slides";
-    src = ./.;
+stdenv.mkDerivation {
+  pname = "openwrt-at-scale";
+  version = "2022-09-31";
 
-    buildInputs = [
-      texlive
-      pkgs.rubber
-    ];
+  src = ./.;
 
-    installPhase = ''
-      mkdir -p $out
-      cp slides.pdf $out/
-    '';
-  };
+  buildInputs = [
+    texLive
+    rubber
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp slides.pdf $out/
+  '';
 }

--- a/openwrt-at-scale/images/autoflash-1.jpg
+++ b/openwrt-at-scale/images/autoflash-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9df5e10841ed74e5fc0a33ac176397771154533f8c3855967ef79c5c9ecee6f
+size 5096446

--- a/openwrt-at-scale/images/autoflash-2.jpg
+++ b/openwrt-at-scale/images/autoflash-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e73cd1daec5d9d46c34be76d30741e66c85090a6ebab9a02c7e3c704679b3410
+size 4657078

--- a/openwrt-at-scale/images/autoflash-3.jpg
+++ b/openwrt-at-scale/images/autoflash-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8c98d7b30254f6feba6c853e68750b565adf151e028908ee02ca8cf8596702f
+size 3864757

--- a/openwrt-at-scale/images/autoflasher-1.png
+++ b/openwrt-at-scale/images/autoflasher-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc49a3b5de533e63bcd591ae5b983025aacce704e5c227fa1c2d9b5212a52b7b
+size 178737

--- a/openwrt-at-scale/images/belkin-rt3200.png
+++ b/openwrt-at-scale/images/belkin-rt3200.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a243ff428047cfd94c116a41c50249cf147f53a68700cf1ad58f725d0066932
+size 89547

--- a/openwrt-at-scale/images/build-weekly-1.png
+++ b/openwrt-at-scale/images/build-weekly-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc49a3b5de533e63bcd591ae5b983025aacce704e5c227fa1c2d9b5212a52b7b
+size 178737

--- a/openwrt-at-scale/images/build-weekly-2.png
+++ b/openwrt-at-scale/images/build-weekly-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6d2baca905e82045001b94c6ee6408418c3bdf223ba0b80b2c9f9bd88ca7bf2
+size 234193

--- a/openwrt-at-scale/images/massflash-1.jpg
+++ b/openwrt-at-scale/images/massflash-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75c0124b93d33b30119e768ccce047b72e16e2a9dcca411d555a5345aebae575
+size 103972

--- a/openwrt-at-scale/images/massflash-2.jpg
+++ b/openwrt-at-scale/images/massflash-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5819d50417105e458a40d0d2d6ea4b4c261d565ed3eb49d5d6c17065bdaf82b2
+size 121551

--- a/openwrt-at-scale/images/massflash-3.jpg
+++ b/openwrt-at-scale/images/massflash-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:776523d7236a5798896750cfa8e63188b4bd98cd1e796b1f28e5d5397ece60e2
+size 195497

--- a/openwrt-at-scale/images/scale-tech.png
+++ b/openwrt-at-scale/images/scale-tech.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94bf6e310e14402a0e3441d2c59e236c0305c9a332ddfc4c11b180211222a05b
+size 53643

--- a/openwrt-at-scale/images/wifi-hard-reset.png
+++ b/openwrt-at-scale/images/wifi-hard-reset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10062a33584fc74d89fec0555962afef74c52d3823a7b4bf323a1e9393ed0986
+size 123186

--- a/openwrt-at-scale/images/wifi-signage.png
+++ b/openwrt-at-scale/images/wifi-signage.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4cf7fe62387eca1e6d2a5f90d4fd133ba746e21688c5374433af96569f431d7
+size 32670

--- a/openwrt-at-scale/images/wndr3700_v2.png
+++ b/openwrt-at-scale/images/wndr3700_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b4c33a444f292edfe9ca6e18f3032f9e2ce801cacc940f0749cf687b8d6fbcf
+size 41275

--- a/openwrt-at-scale/snippets/golden.sh
+++ b/openwrt-at-scale/snippets/golden.sh
@@ -1,0 +1,3 @@
+gen_templates $TMPLOC
+
+diff -u -r "golden/$TARGET" $TMPLOC/

--- a/openwrt-at-scale/snippets/serverspec.rb
+++ b/openwrt-at-scale/snippets/serverspec.rb
@@ -1,0 +1,6 @@
+describe file('/etc/config/network') do
+    it { should exist }
+    it { should be_symlink }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+end

--- a/simple/Makefile
+++ b/simple/Makefile
@@ -1,0 +1,7 @@
+default: slides.pdf
+
+slides.pdf: slides.tex
+	rubber --pdf slides.tex
+
+view: slides.pdf
+	atril slides.pdf

--- a/simple/default.nix
+++ b/simple/default.nix
@@ -1,0 +1,18 @@
+{ texLive, rubber, stdenv, lib }:
+
+stdenv.mkDerivation {
+  pname = "simple-slides";
+  version = "1970-01-01";
+
+  src = ./.;
+
+  buildInputs = [
+    texLive
+    rubber
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp slides.pdf $out/
+  '';
+}

--- a/simple/slides.tex
+++ b/simple/slides.tex
@@ -1,0 +1,46 @@
+\documentclass{beamer}
+
+\usetheme[progressbar=frametitle]{metropolis}
+%\setbeamertemplate{frame numbering}[fraction]
+\useoutertheme{metropolis}
+\useinnertheme{metropolis}
+\usefonttheme{metropolis}
+\usecolortheme{spruce}
+\setbeamercolor{background canvas}{bg=white}
+
+\usepackage{listings}
+% storing our images
+
+%Information to be included in the title page:
+\title{Simple Example Talk}
+\subtitle{Testing tex and beamer compilation}
+\author{
+  Robert Hernandez \\
+}
+\date{Jan 1970}
+
+\setbeameroption{hide notes} % Only slides
+%\setbeameroption{show only notes} % Only notes
+%\setbeameroption{show notes on second screen=right} % Both
+
+%\setbeamertemplate{note page}{\pagecolor{yellow!5}\insertnote}\usepackage{palatino}
+
+\begin{document}
+\metroset{block=fill}
+\frame{\titlepage}
+
+\begin{frame}
+\frametitle{This talk}
+  \begin{center}
+  {\large \textbf{https://github.com/sarcasticadmin/talks}}
+  \end{center}
+\end{frame}
+
+\begin{frame}
+\frametitle{End}
+  \begin{center}
+  {\large \textbf{Thank you}}
+  \end{center}
+\end{frame}
+
+\end{document}


### PR DESCRIPTION
## Description

- Able to build slides via `nix build`
- `simple-slides` pkg from testing
- Adding missing images and snippets from scale-19x talk

## Testing

Build the slides:

```
nix build '.#openwrt-at-scale'
nix build '.#simple-slides'
```

```
~$ git lfs ls-files
c9df5e1084 * openwrt-at-scale/images/autoflash-1.jpg
e73cd1daec * openwrt-at-scale/images/autoflash-2.jpg
c8c98d7b30 * openwrt-at-scale/images/autoflash-3.jpg
fc49a3b5de * openwrt-at-scale/images/autoflasher-1.png
5a243ff428 * openwrt-at-scale/images/belkin-rt3200.png
fc49a3b5de * openwrt-at-scale/images/build-weekly-1.png
a6d2baca90 * openwrt-at-scale/images/build-weekly-2.png
75c0124b93 * openwrt-at-scale/images/massflash-1.jpg
5819d50417 * openwrt-at-scale/images/massflash-2.jpg
776523d723 * openwrt-at-scale/images/massflash-3.jpg
94bf6e310e * openwrt-at-scale/images/scale-tech.png
10062a3358 * openwrt-at-scale/images/wifi-hard-reset.png
f4cf7fe623 * openwrt-at-scale/images/wifi-signage.png
8b4c33a444 * openwrt-at-scale/images/wndr3700_v2.png
```